### PR TITLE
Add ACME redirects for Let’s Encrypt

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,6 +5,14 @@
 [build.environment]
   NODE_VERSION = "20"
 
+# 1) ACME challenge passthrough (must be ABOVE the SPA rule)
+[[redirects]]
+  from = "/.well-known/acme-challenge/*"
+  to = "/acme/:splat"
+  status = 200
+  force = true
+
+# 2) SPA fallback
 [[redirects]]
   from = "/*"
   to = "/index.html"


### PR DESCRIPTION
Adds /.well-known/acme-challenge passthrough and keeps SPA fallback below it.